### PR TITLE
fix an endless loop (not happening in this version)

### DIFF
--- a/src/vgr2dlib.c
+++ b/src/vgr2dlib.c
@@ -185,7 +185,7 @@ static void poly_get_active(poly_iter_t *iter) {
 
   poly_advance(iter, iter->y);
   while (iter->n_active == 0 && iter->idx < iter->n_edges) {
-    iter->y += 1;
+    iter->idx += 1;
   }
 
   // sort and update


### PR DESCRIPTION
The endless loop only appears while converting the array `uint16_t pts[]` to `int16_t pts[]` in the source (possibly the way ahead to fix the negative coordinate not being supported).