### PR TITLE
Signed coordinates

### DIFF
--- a/src/modvgr2d.c
+++ b/src/modvgr2d.c
@@ -168,7 +168,7 @@ static mp_obj_t polygon_make_new(const mp_obj_type_t *type, size_t n_args, size_
   mp_obj_list_get(args[0], &list_len, &list);
 
   self->poly.n_pts = 2*list_len+2;
-  self->poly.pts = m_new(uint16_t, self->poly.n_pts);
+  self->poly.pts = m_new(int16_t, self->poly.n_pts);
 
   int i, j;
   for (i = 0, j = 0; i < list_len; i++, j+=2) {
@@ -251,7 +251,7 @@ static mp_obj_t polyline_make_new(const mp_obj_type_t *type, size_t n_args, size
   mp_obj_list_get(args[0], &list_len, &list);
 
   self->poly.n_pts = 2*list_len;
-  self->poly.pts = m_new(uint16_t, self->poly.n_pts);
+  self->poly.pts = m_new(int16_t, self->poly.n_pts);
 
   int i, j;
   for (i = 0, j = 0; i < list_len; i++, j+=2) {
@@ -328,7 +328,7 @@ static mp_obj_t line_make_new(const mp_obj_type_t *type, size_t n_args, size_t n
     mp_raise_ValueError(MP_ERROR_TEXT("Stoke width must be at least 1"));
 
   self->poly.n_pts = 4;
-  self->poly.pts = m_new(uint16_t, self->poly.n_pts);
+  self->poly.pts = m_new(int16_t, self->poly.n_pts);
 
   int i, j;
   for (i = 0, j = 0; i < 2; i++, j+=2) {
@@ -416,7 +416,7 @@ static iter_base_t *make_iter(mp_obj_t obj) {
 static int sort_runs(uint16_t *runs, uint8_t *clr, int nx) {
   int n = nx>>1;
   uint8_t c;
-  uint16_t x1, x2;
+  int16_t x1, x2;
 
   for (int i = 0; i < n; i++) {
     for (int j = n-1; j > i; j--) {
@@ -440,7 +440,7 @@ static int sort_runs(uint16_t *runs, uint8_t *clr, int nx) {
   int ri = 2;
   for (int i = 1; i < n; i++) {
     if (runs[ri] >= runs[oi-1]) {
-      uint16_t dx = runs[ri]-runs[oi-1];
+      int16_t dx = runs[ri]-runs[oi-1];
       // dx 0 is okay, otherwise must meet minimum
       if (dx != 0) {
 	if (XFX_INT(runs[ri]) == (XFX_INT(runs[oi-1])+1)) {
@@ -492,8 +492,8 @@ static mp_obj_t generate(size_t n_args, const mp_obj_t *args) {
   int len = (int)list_len;
 
   uint16_t cmd;
-  uint16_t curY, y, prevY;
-  uint16_t x1, x2, dx, dx0, s, s0, curX;
+  int16_t curY, y, prevY;
+  int16_t x1, x2, dx, dx0, s, s0, curX;
   uint8_t c;
   int i, ri;
 
@@ -509,10 +509,10 @@ static mp_obj_t generate(size_t n_args, const mp_obj_t *args) {
   mp_obj_list_append(return_list, MP_OBJ_NEW_SMALL_INT(addr>>8));
   mp_obj_list_append(return_list, MP_OBJ_NEW_SMALL_INT(addr&0xff));
 
-  prevY = 0xffff;
+  prevY = INT16_MAX;
   do {
     // find next closest line
-    curY = 0xffff;
+    curY = INT16_MAX;
     for (i = 0; i < len; i++) {
       if (iters[i] != NULL) {
 	if (iters[i]->nextLine(iters[i], &y)) {
@@ -524,7 +524,7 @@ static mp_obj_t generate(size_t n_args, const mp_obj_t *args) {
 	}
       }
     }
-    if (curY == 0xffff || curY >= yres) break;
+    if (curY == INT16_MAX || curY >= yres) break;
 
     // collect runs on this line
     ri = 0;

--- a/src/vgr2dlib.h
+++ b/src/vgr2dlib.h
@@ -33,8 +33,8 @@ limitations under the License.
 
 typedef struct iter_base_s {
   size_t size;
-  bool (*nextLine)(void *, uint16_t*);
-  bool (*nextRun)(void *, uint16_t, uint16_t*, uint16_t*, uint8_t*);
+  bool (*nextLine)(void *, int16_t*);
+  bool (*nextRun)(void *, int16_t, int16_t*, int16_t*, uint8_t*);
 } iter_base_t;
 
 typedef struct edge {
@@ -55,13 +55,13 @@ typedef struct rectangle_s {
   transform_t tr;
   bool fill, stroke;
   uint8_t fclr,sclr;
-  uint16_t w, h;
+  int16_t w, h;
 } rectangle_t;
 
 typedef struct rect_iter_s {
   iter_base_t base;
-  uint16_t y, y2;
-  uint16_t x1, x2;
+  int16_t y, y2;
+  int16_t x1, x2;
   uint8_t clr;
 } rect_iter_t;
 
@@ -70,7 +70,7 @@ typedef struct polygon_s {
   transform_t tr;
   bool fill, stroke;
   uint8_t fclr,sclr;
-  uint16_t *pts;
+  int16_t *pts;
   int n_pts, width;
 } polygon_t;
 
@@ -83,7 +83,7 @@ typedef struct poly_iter_s {
   int16_t x_coords[MAX_ACTIVE];
   uint16_t idmap[MAX_ACTIVE];
   int n_active, cur, width;
-  uint16_t ty, tx, y0, y;
+  int16_t ty, tx, y0, y;
   bool fill, stroke;
   uint8_t fclr, sclr;
 } poly_iter_t;


### PR DESCRIPTION
This allows coordinates to be signed internally, which avoids the initial conversion from `int16_t` to `uint16_t` likely causing an underflow:

For instance in `modvgr2d.c`:
```C
261     if (tpl_len==2) {
262       self->poly.pts[j] = XFX(mp_obj_get_int(tpl[0]));
263       self->poly.pts[j+1] = YFX(mp_obj_get_int(tpl[1]));
264     } else {
...
```

It still appear to work after this change:
![mpv-shot0125](https://user-images.githubusercontent.com/55351021/235705452-5bd38dda-3430-42f1-8cbd-78417a0ecddf.jpg)
